### PR TITLE
#21: JSON Error serialization (closes #21)

### DIFF
--- a/src/main/scala/webresult/DefaultMarshallingSupport.scala
+++ b/src/main/scala/webresult/DefaultMarshallingSupport.scala
@@ -5,12 +5,14 @@ import spray.http.{ StatusCode, StatusCodes }
 trait DefaultMarshallingSupport extends MarshallingSupport {
 
   implicit def webErrorToStatusCode(webError: WebError) = webError match {
-    case WebError.InvalidParam(_, _)  => StatusCodes.UnprocessableEntity
-    case WebError.InvalidParams(_)    => StatusCodes.UnprocessableEntity
-    case WebError.InvalidOperation(_) => StatusCodes.UnprocessableEntity
-    case WebError.InvalidCredentials  => StatusCodes.Unauthorized
-    case WebError.Forbidden(_)        => StatusCodes.Forbidden
-    case WebError.NotFound            => StatusCodes.NotFound
+    case WebError.InvalidParam(_, _)              => StatusCodes.UnprocessableEntity
+    case WebError.InvalidParams(_)                => StatusCodes.UnprocessableEntity
+    case WebError.InvalidOperation(_)             => StatusCodes.UnprocessableEntity
+    case WebError.InvalidCredentials              => StatusCodes.Unauthorized
+    case WebError.Forbidden(_)                    => StatusCodes.Forbidden
+    case WebError.NotFound                        => StatusCodes.NotFound
+    case WebError.GenericError(statusCode, _)     => statusCode
+    case WebError.GenericErrors(statusCode, _)    => statusCode
   }
 
   implicit def webErrorToMessageString(webError: WebError) = webError match {
@@ -20,9 +22,14 @@ trait DefaultMarshallingSupport extends MarshallingSupport {
       val errors = params mkString ", "
       s"Invalid parameters: $errors"
     }
-    case WebError.InvalidOperation(desc) => s"Invalid operation. $desc"
-    case WebError.InvalidCredentials     => "Invalid credentials"
-    case WebError.NotFound               => "Not found"
+    case WebError.InvalidOperation(desc)   => s"Invalid operation. $desc"
+    case WebError.InvalidCredentials       => "Invalid credentials"
+    case WebError.NotFound                 => "Not found"
+    case WebError.GenericError(_, error)   => error.desc
+    case WebError.GenericErrors(_, errors) => {
+      val errorsDesc = errors mkString ", "
+      s"Errors description: $errorsDesc"
+    }
   }
 
 }

--- a/src/main/scala/webresult/package.scala
+++ b/src/main/scala/webresult/package.scala
@@ -11,8 +11,14 @@ object WebError {
   case object InvalidCredentials extends WebError
   case class Forbidden(desc: String) extends WebError
   case object NotFound extends WebError
+  case class GenericError(statusCode: StatusCode, error: GenericErrorDesc) extends WebError
+  case class GenericErrors(statusCode: StatusCode, errors: List[GenericErrorDesc]) extends WebError
 }
 
 trait WebSuccess[T] {
   val value: T
+}
+
+trait GenericErrorDesc {
+  def desc: String
 }


### PR DESCRIPTION
Issue #21

This allows to define custom errors. It's a "temporary fix" to make `WebError` usable.
This module requires a complete rework.
